### PR TITLE
Set update_time on full executable dictionary update

### DIFF
--- a/dbms/src/Dictionaries/ExecutableDictionarySource.cpp
+++ b/dbms/src/Dictionaries/ExecutableDictionarySource.cpp
@@ -88,6 +88,7 @@ std::string ExecutableDictionarySource::getUpdateFieldAndDate()
     }
     else
     {
+        update_time = std::chrono::system_clock::now();
         std::string str_time("\"0000-00-00 00:00:00\""); ///for initial load
         return command + " " + update_field + " " + str_time;
     }


### PR DESCRIPTION
This fixes issue #4524.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Bug Fix

Short description (up to few sentences):
Set update_time on full executable dictionary update.

Detailed description (optional):

...
